### PR TITLE
feat(docrun): Docrun extracts and runs example code from documentation

### DIFF
--- a/doc_analyzer.go
+++ b/doc_analyzer.go
@@ -1,0 +1,52 @@
+package main
+
+import (
+	"io"
+	"io/ioutil"
+
+	"github.com/gomarkdown/markdown"
+	"github.com/gomarkdown/markdown/ast"
+	"github.com/gomarkdown/markdown/html"
+	golog "github.com/ipfs/go-log"
+	"github.com/qri-io/docrun/framework"
+)
+
+// The actual DocRun processor, given each node as they are parsed.
+var runner framework.DocRunner
+
+// renderHook is called by markdown parser for each ast node.
+func renderHook(w io.Writer, node ast.Node, entering bool) (ast.WalkStatus, bool) {
+	// Only process nodes when they open up.
+	if entering {
+		runner.AddNode(node)
+	}
+	// Tell the parser to continue walking the ast normally.
+	return ast.GoToNext, false
+}
+
+func docAnalyze(path string, logLevel int) {
+	// Assign log level to the logger.
+	if logLevel == 1 {
+		golog.SetLogLevel("docrun", "info")
+	} else if logLevel == 2 {
+		golog.SetLogLevel("docrun", "debug")
+	}
+	// This library converts markdown to html, with a hook for parsed nodes. We ignore the html
+	// output, and only care about the ast nodes while parsing is happening.
+	opts := html.RendererOptions{
+		Flags:          html.CommonFlags,
+		RenderNodeHook: renderHook,
+	}
+	renderer := html.NewRenderer(opts)
+	md, err := ioutil.ReadFile(path)
+	if err != nil {
+		panic(err)
+	}
+	// Parse markdown to collect and run test cases.
+	runner.Init()
+	_ = markdown.ToHTML([]byte(md), nil, renderer)
+	if runner.HasError() {
+		runner.ShowErrors()
+	}
+	runner.DisplayResults()
+}

--- a/framework/command_line.go
+++ b/framework/command_line.go
@@ -1,0 +1,19 @@
+package framework
+
+import (
+	"fmt"
+)
+
+// CommandLineRunner collects methods for running commands
+type CommandLineRunner struct {
+}
+
+// NewCommandLineRunner returns a new CommandLineRunner
+func NewCommandLineRunner() *CommandLineRunner {
+	return nil
+}
+
+// Run executes a command
+func (r *CommandLineRunner) Run(details *commandDetails, sourceCode string) error {
+	return fmt.Errorf("IMPLEMENT ME")
+}

--- a/framework/data.go
+++ b/framework/data.go
@@ -1,0 +1,50 @@
+package framework
+
+// DocrunFixture is a wrapper that doesn't do much aside from cause metadata blocks to need to
+// begin with the text "docrun:" so that it's obvious that they're using docrun.
+type DocrunFixture struct {
+	Docrun docrunDetails
+}
+
+// docrunDetails holds all the metadata about the source code that follows it.
+type docrunDetails struct {
+	// Only one of the following three fields should be specified
+	Pass    bool
+	Test    *testDetails
+	Command *commandDetails
+	// These two fields are entirely optional
+	Lang string
+	Save *saveDetails
+}
+
+// testDetails holds metadata about a test case. Expected results are recorded in this structure.
+type testDetails struct {
+	WebProxy *proxyDetails
+	Setup    string
+	Call     string
+	Actual   string
+	Expect   interface{}
+}
+
+// proxyDetails is used for tests that need a mock http response
+type proxyDetails struct {
+	URL      string
+	Response interface{}
+}
+
+// saveDetails is used to save source code to a file for future commands
+type saveDetails struct {
+	Filename string
+	Append   bool
+}
+
+// DocrunSource is parsed source code, which may have a specified language
+type DocrunSource struct {
+	Code string
+	Lang string
+}
+
+// commandDetails holds information about commands to run
+type commandDetails struct {
+	SnapshotID string `json:"snapshotid"`
+}

--- a/framework/framework.go
+++ b/framework/framework.go
@@ -1,0 +1,224 @@
+// Package framework is the main implementation of docrun. It accumulates data about test fixtures
+// along with source code extracted from markdown files. Then it runs that source code and makes
+// sure the results match what is expected.
+package framework
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/gomarkdown/markdown/ast"
+	"github.com/qri-io/qri/base/fill"
+	"gopkg.in/yaml.v2"
+)
+
+// DocRunner maintains state to process nodes, run examples, and collect results
+type DocRunner struct {
+	Errs        []error
+	Count       int
+	Fixture     *DocrunFixture
+	Source      *DocrunSource
+	Results     runResults
+	Starlark    *StarlarkRunner
+	CommandLine *CommandLineRunner
+}
+
+type runResults struct {
+	countSuccess int
+	countTrivial int
+}
+
+func (r *runResults) AddSuccess(caseNum int, nonTrivial bool) {
+	r.countSuccess++
+	if !nonTrivial {
+		r.countTrivial++
+	}
+}
+
+// Init assigns initial state to the DocRunner
+func (f *DocRunner) Init() {
+	f.Starlark = NewStarlarkRunner()
+	f.CommandLine = NewCommandLineRunner()
+}
+
+// HandleNode is given each parsed ast node, and collects information about tests to run
+func (f *DocRunner) HandleNode(node ast.Node) (*DocrunFixture, *DocrunSource, error) {
+	// A fixture begins with an HTML comment block containing metadata about a test to run.
+	if _, ok := node.(*ast.HTMLBlock); ok {
+		leaf := node.AsLeaf()
+		if leaf != nil {
+			text := strings.Trim(string(leaf.Literal), " \n")
+			if strings.HasPrefix(text, "<!--") && strings.HasSuffix(text, "-->") {
+				text = text[4 : len(text)-3]
+				// TODO(dlong): Only continue if the comment block begins with the text "docrun".
+
+				var fields map[string]interface{}
+				err := yaml.Unmarshal([]byte(text), &fields)
+				if err != nil {
+					return nil, nil, err
+				}
+
+				fixture := DocrunFixture{}
+				err = fill.Struct(fields, &fixture)
+				if err != nil {
+					return nil, nil, err
+				}
+				return &fixture, nil, nil
+			}
+		}
+	}
+
+	// A code block is treated as source code that can be run, as long as it has valid metadata.
+	if cb, ok := node.(*ast.CodeBlock); ok {
+		leaf := node.AsLeaf()
+		if leaf != nil {
+			return nil, &DocrunSource{string(leaf.Literal), string(cb.Info)}, nil
+		}
+	}
+
+	return nil, nil, nil
+}
+
+// AddNode collects a node, either a fixture represented by a HTML comment block, or source code.
+func (f *DocRunner) AddNode(node ast.Node) {
+	fixture, source, err := f.HandleNode(node)
+	if err != nil {
+		f.AddError(err)
+		return
+	}
+	if f.Fixture == nil && fixture != nil {
+		// Hold onto fixture until the source code is also parsed.
+		f.Fixture = fixture
+		return
+	}
+	if f.Source == nil && source != nil {
+		// Once fixture and source are available, run the test case.
+		f.Source = source
+		f.RunFixture()
+		f.Fixture = nil
+		f.Source = nil
+	}
+}
+
+// RunFixture runs a fixture by combining metadata and the source code.
+func (f *DocRunner) RunFixture() {
+	f.Count++
+	if f.Fixture == nil {
+		// Source code blocks should all be immediately preceded by a fixture node. It is an error
+		// to have source code without a fixture node. An easy to silence this is to add:
+		// <!--
+		// docrun:
+		//   pass: true
+		// -->
+		f.AddError(fmt.Errorf("source code block %d is not preceded by a docrun fixture", f.Count))
+		return
+	}
+	if f.Fixture.Docrun.Pass {
+		// A trivially passing test.
+		f.Results.AddSuccess(f.Count, false)
+		return
+	}
+
+	lang := ""
+	// If source code has a language tag, use that for the source language.
+	if f.Source.Lang != "" {
+		lang = f.Source.Lang
+	}
+	// Otherwise, if top-level of fixture has a language field, use that.
+	// TODO(dlong): Should it be an error to have both set?
+	if lang == "" && f.Fixture.Docrun.Lang != "" {
+		lang = f.Fixture.Docrun.Lang
+	}
+	if lang == "" {
+		f.AddError(fmt.Errorf("source code block %d has no language", f.Count))
+		return
+	}
+
+	// If there's a test substructure, dispatch it.
+	test := f.Fixture.Docrun.Test
+	if test != nil {
+		f.DispatchTestCase(test, lang, f.Source.Code)
+		f.HandleSave(f.Fixture.Docrun.Save, f.Source.Code)
+		return
+	}
+	// If there's a command, dispatch it.
+	cmd := f.Fixture.Docrun.Command
+	if cmd != nil {
+		f.DispatchCommandCase(cmd, lang, f.Source.Code)
+		f.HandleSave(f.Fixture.Docrun.Save, f.Source.Code)
+		return
+	}
+	f.HandleSave(f.Fixture.Docrun.Save, f.Source.Code)
+}
+
+// HandleSave saves the source code to a file, for future tests and commands.
+func (f *DocRunner) HandleSave(save *saveDetails, sourceCode string) {
+	if save == nil {
+		return
+	}
+	if save.Append {
+		// TODO(dlong): Implement appending this source to the file
+	} else {
+		// TODO(dlong): Implement overwriting the file
+	}
+}
+
+// HasError returns whether there were any errors
+func (f *DocRunner) HasError() bool {
+	return len(f.Errs) > 0
+}
+
+// ShowErrors displays errors to stdout
+func (f *DocRunner) ShowErrors() {
+	for _, err := range f.Errs {
+		fmt.Printf("Error: %s\n", err)
+	}
+}
+
+// AddError adds an error
+func (f *DocRunner) AddError(err error) {
+	f.Errs = append(f.Errs, err)
+}
+
+// DisplayResults displays results from running the test cases.
+func (f *DocRunner) DisplayResults() {
+	if f.Results.countTrivial == 0 {
+		fmt.Printf("PASS: %d tests\n", f.Results.countSuccess)
+	} else {
+		fmt.Printf("PASS: %d tests (%d trivial)\n", f.Results.countSuccess, f.Results.countTrivial)
+	}
+	fmt.Printf("FAIL: %d\n", f.Count-f.Results.countSuccess)
+}
+
+// DispatchTestCase dispatches a test case.
+func (f *DocRunner) DispatchTestCase(test *testDetails, lang, source string) {
+	var err error
+	switch lang {
+	case "python":
+		err = f.Starlark.Run(test, source)
+	default:
+		err = fmt.Errorf("unknown code language %s", lang)
+	}
+	if err != nil {
+		f.AddError(err)
+	} else {
+		f.Results.AddSuccess(f.Count, true)
+	}
+}
+
+// DispatchCommandCase dispatches a command.
+// TODO(dlong): Implementation is only a stub currently.
+func (f *DocRunner) DispatchCommandCase(cmd *commandDetails, lang, source string) {
+	var err error
+	switch lang {
+	case "shell":
+		err = f.CommandLine.Run(cmd, source)
+	default:
+		err = fmt.Errorf("unknown code language %s", lang)
+	}
+	if err != nil {
+		f.AddError(err)
+	} else {
+		f.Results.AddSuccess(f.Count, true)
+	}
+}

--- a/framework/starlark.go
+++ b/framework/starlark.go
@@ -1,0 +1,165 @@
+package framework
+
+import (
+	"encoding/json"
+	"fmt"
+	"reflect"
+	"strings"
+
+	golog "github.com/ipfs/go-log"
+	"github.com/qri-io/dataset"
+	starutil "github.com/qri-io/starlib/util"
+	"github.com/qri-io/startf/context"
+	stards "github.com/qri-io/startf/ds"
+	"go.starlark.net/starlark"
+	"go.starlark.net/starlarkstruct"
+)
+
+var log = golog.Logger("docrun")
+
+// StarlarkRunner collects methods for running starlark code
+type StarlarkRunner struct {
+}
+
+// NewStarlarkRunner returns a new StarlarkRunner
+func NewStarlarkRunner() *StarlarkRunner {
+	return &StarlarkRunner{}
+}
+
+// ModuleLoader can load starlark modules (like http)
+type ModuleLoader func(thread *starlark.Thread, module string) (starlark.StringDict, error)
+
+// NewMockModuleLoader returns a ModuleLoader to load mock modules
+func NewMockModuleLoader(proxy *proxyDetails) ModuleLoader {
+	return func(thread *starlark.Thread, module string) (dict starlark.StringDict, err error) {
+		m := &MockHTTPModule{proxy: proxy}
+		// TODO(dlong): Add other mock implementations, as needed
+		return starlark.StringDict{
+			"http": m.Struct(),
+		}, nil
+	}
+}
+
+// MockHTTPModule is a module for mocking out http functionality.
+type MockHTTPModule struct {
+	proxy *proxyDetails
+}
+
+// Struct returns a starlark struct with methods
+func (m *MockHTTPModule) Struct() *starlarkstruct.Struct {
+	return starlarkstruct.FromStringDict(starlarkstruct.Default, m.StringDict())
+}
+
+// StringDict returns the module as a dictionary keyed by strings
+func (m *MockHTTPModule) StringDict() starlark.StringDict {
+	return starlark.StringDict{
+		"get": starlark.NewBuiltin("get", m.get),
+	}
+}
+
+// get performs a mock http request
+func (m *MockHTTPModule) get(thread *starlark.Thread, _ *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
+	if m.proxy != nil {
+		// TODO: Check get's argument against m.proxy.URL
+		result, err := starutil.Marshal(m.proxy.Response)
+		if err != nil {
+			return starlark.None, err
+		}
+		return result, nil
+	}
+	return starlark.None, fmt.Errorf("Cannot use http.get without WebProxy")
+}
+
+// Run runs the actual starlark code from a test case.
+func (r *StarlarkRunner) Run(details *testDetails, sourceCode string) error {
+	// Log information about the test before running it (debug level only).
+	log.Debugf("==============================")
+	log.Debugf("WebProxy: %p", details.WebProxy)
+	log.Debugf("Setup:  %s", details.Setup)
+	log.Debugf("Call:   %s", details.Call)
+	log.Debugf("Actual: %s", details.Actual)
+	log.Debugf("Expect: %s", details.Expect)
+	log.Debugf("code: {%s}", sourceCode)
+	log.Debugf("------------------------------")
+
+	var err error
+	thread := &starlark.Thread{
+		Load: NewMockModuleLoader(details.WebProxy),
+	}
+	// Environment has `ds` and `ctx` predefined.
+	environment := make(map[string]starlark.Value)
+	ds := stards.Dataset{}
+	ds.SetMutable(&dataset.Dataset{})
+	ctx := context.NewContext(make(map[string]interface{}), make(map[string]interface{}))
+
+	environment["ds"] = ds.Methods()
+	environment["ctx"] = ctx.Struct()
+	// Setup is either modifying a field of context (handled specially), or mutates an existing
+	// variable (such as calling set_body on ds). It won't modify the top-level environment.
+	if details.Setup != "" {
+		log.Info("running Setup...")
+		if strings.HasPrefix(details.Setup, "ctx.download = ") {
+			// TODO: Actual implementation
+			result := starlark.NewList([]starlark.Value{starlark.Value(starlark.String("test"))})
+			ctx.SetResult("download", result)
+		} else {
+			_, err = starlark.ExecFile(thread, "", details.Setup, environment)
+			if err != nil {
+				return fmt.Errorf("during Setup: %s", err.Error())
+			}
+		}
+	}
+
+	environment["ds"] = ds.Methods()
+	environment["ctx"] = ctx.Struct()
+	// Run sourceCode
+	log.Info("running code block...")
+	environment, err = starlark.ExecFile(thread, "", sourceCode, environment)
+	if err != nil {
+		return fmt.Errorf("running code block: %s", err.Error())
+	}
+
+	environment["ds"] = ds.Methods()
+	environment["ctx"] = ctx.Struct()
+	// Call is the entry point to run in order to exercise the test case.
+	// TODO(dlong): Validate that this is a single function
+	log.Info("running Call...")
+	environment, err = starlark.ExecFile(thread, "", "result = "+details.Call, environment)
+	if err != nil {
+		return fmt.Errorf("during Call: %s", err.Error())
+	}
+
+	// Assign special function results to ctx field
+	if strings.HasPrefix(details.Call, "download") {
+		ctx.SetResult("download", environment["result"])
+	}
+
+	environment["ds"] = ds.Methods()
+	environment["ctx"] = ctx.Struct()
+	// Actual accesses the results of the test case.
+	// TODO(dlong): Validate that this is an expression (should not have side-effects)
+	log.Info("running Actual...")
+	environment, err = starlark.ExecFile(thread, "", "result = "+details.Actual, environment)
+	if err != nil {
+		return fmt.Errorf("during Actual: %s", err.Error())
+	}
+
+	// Parse the results from Actual into a native data structure.
+	var actual interface{}
+	resultStr := environment["result"].String()
+	err = json.Unmarshal([]byte(resultStr), &actual)
+	if err != nil {
+		return fmt.Errorf("parsing \"%s\": %s", resultStr, err.Error())
+	}
+
+	// Compare actual results against the expected results, fail if different.
+	if !reflect.DeepEqual(actual, details.Expect) {
+		tmpl := `test case failure
+actual: %s
+expect: %s`
+		return fmt.Errorf(tmpl, actual, details.Expect)
+	}
+
+	log.Info("success!")
+	return nil
+}

--- a/main.go
+++ b/main.go
@@ -1,0 +1,34 @@
+// Docrun is a utility to extract source code examples from markdown files, and execute those
+// examples in order to verify that they work correctly.
+package main
+
+import (
+	"flag"
+	"fmt"
+	"os"
+)
+
+// TODO(dlong): This first implementation is being used to act as a prototype in order to
+// finalize the design of docrun. In the near future, add tests and documentation.
+
+func main() {
+	verbosePtr := flag.Bool("v", false, "verbose logging to show more info")
+	veryVerbosePtr := flag.Bool("vv", false, "very verbose logging to show debug info")
+	flag.Parse()
+
+	if len(flag.Args()) == 0 {
+		fmt.Printf("Usage: docrun [options] filename\n")
+		os.Exit(1)
+	}
+
+	filename := flag.Args()[0]
+	logLevel := 0
+	if *verbosePtr {
+		logLevel = 1
+	}
+	if *veryVerbosePtr {
+		logLevel = 2
+	}
+
+	docAnalyze(filename, logLevel)
+}


### PR DESCRIPTION
Docrun provides a literate programming like environment for markdown files. It extracts example code snippets, along with metadata embedded in html, and runs the example code, making sure it returns the expected result.

This first commit is a prototype proof-of-concept to demonstrate how it works. Both documentation and tests are needed, but those will be added after the design of this prototype is agreed upon.